### PR TITLE
Clone DateTime parameters to avoid modifying the references

### DIFF
--- a/src/Holiday/Calculator.php
+++ b/src/Holiday/Calculator.php
@@ -69,7 +69,10 @@ abstract class Calculator
      */
     public function between(\DateTime $start, \DateTime $end)
     {
-        // Comparing DateTime also looks at the time. So we need to make sure the time is 0.
+        // Comparing DateTime also looks at the time. So we need to make sure the time is 0,
+        // but don't modify the original referenced DateTime parameters
+        $start = clone $start;
+        $end = clone $end;
         $start->setTime(0, 0, 0);
         $end->setTime(0, 0, 0);
 


### PR DESCRIPTION
This threw me off for a bit.
I was trying to do a `DateTime` comparison after using `between()`, which would mess up the comparison since it sets the time to `00::00::00`.
