### PR TITLE
Require the php extension calendar.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "psr-0": {"Holiday": "src/"}
     },
     "require": {
-        "php": ">= 5.4"
+        "php": ">= 5.4",
+        "ext-calendar": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
In [Calculator.php:58](https://github.com/mayflower/libholiday/blob/master/src/Holiday/Calculator.php#L58) the function easter_days is being used.

This function is part of the calendar PHP extension, and hence it is needed to make users aware of this by adding it as a composer dependency.