### PR TITLE
Test with recent PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm-nightly
+  - 7.1
+  - 7.2
+  - 7.3
 
 matrix:
   allow_failures:
-    - php: hhvm-nightly
+    - php: 7.3
 
 before_script:
-  - composer --prefer-source --dev install
+  - composer --prefer-source install
 script:
   - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ php:
   - 7.2
   - 7.3
 
-matrix:
-  allow_failures:
-    - php: 7.3
-
 before_script:
   - composer --prefer-source install
 script:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-0": {"Holiday": "src/"}
     },
     "require": {
-        "php": ">= 5.4",
+        "php": "^5.4 || ^7.0",
         "ext-calendar": "*"
     },
     "require-dev": {


### PR DESCRIPTION
* Test with recent PHP versions to ensure that the versions being supported next year work with this library as well
* Fix version constraint of `php` to match best practices (no unbound constraints)